### PR TITLE
Improve metadata in German localization

### DIFF
--- a/locale/de_DE/locale.xml
+++ b/locale/de_DE/locale.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE locale SYSTEM "../../../../lib/pkp/dtd/locale.dtd">
+<!DOCTYPE locale SYSTEM "../../../../../lib/pkp/dtd/locale.dtd">
 
 <!--
-  * locale/de_DE/locale.xml
+  * plugins/generic/disqus/locale/de_DE/locale.xml
   *
   * Copyright (c) 2014-2017 Simon Fraser University
   * Copyright (c) 2003-2017 John Willinsky
   * Distributed under the GNU GPL v2. For full terms see the file docs/COPYING.
   *
-  * Localization strings.
+  * disqus plugin localization strings
   -->
 
-<locale name="de_DE" full_name="Deutsch">
+<locale name="de_DE" full_name="Deutsch (Deutschland)">
 	<message key="plugins.generic.disqus.displayName">Disqus Plugin</message>
 	<message key="plugins.generic.disqus.description">Integriert ein Disqus-Forum in den Artikelübersichtsseiten</message>
-	<message key="plugins.generic.disqus.manager.settings.description">Vergessen Sie nicht den Kurznamen Ihres Forums anzugeben</message>
+	<message key="plugins.generic.disqus.manager.settings.description">Vergessen Sie nicht den Kurznamen Ihres Forums anzugeben.</message>
 	<message key="plugins.generic.disqus.manager.settings.disqusForumName">Kurzname des Disqus-Forums</message>
 	<message key="plugins.generic.disqus.manager.settings.disqusForumNameRequired">Kurzname des Disqus-Forums ist erforderlich</message>
 </locale>


### PR DESCRIPTION
Sorry, the translate plugin does not fill that out all metadata as they should be. Therefore, I had to correct that by hand.